### PR TITLE
Fix font names in theme.txt file to match actual font names

### DIFF
--- a/breeze/theme.txt
+++ b/breeze/theme.txt
@@ -9,11 +9,11 @@ desktop-image: "background.png"
 
 # colors are taken from the breeze default theme
 title-text: "Select a boot option"
-title-font: "Hack 18"
+title-font: "Hack Regular 18"
 title-color: "#eff0f1"
-message-font: "Hack 18"
+message-font: "Hack Regular 18"
 message-color: "#eff0f1"
-terminal-font: "Hack 18"
+terminal-font: "Hack Regular 18"
 terminal-box: "terminal_*.png"
 
 + boot_menu {
@@ -24,7 +24,7 @@ terminal-box: "terminal_*.png"
 
   menu_pixmap_style = "boot_menu_*.png"
 
-  item_font = "Hack 22"
+  item_font = "Hack Regular 22"
   # breeze inactive text color
   item_color = "#7f8c8d"
   item_height = 48
@@ -32,7 +32,7 @@ terminal-box: "terminal_*.png"
   item_spacing = 5
   item_padding = 5
 
-  selected_item_font = "Hack 22"
+  selected_item_font = "Hack Regular 22"
   selected_item_color= "#eff0f1"
   selected_item_pixmap_style = "select_*.png"
 


### PR DESCRIPTION
The names specified in the Hack font files in the theme are of the form **Hack Regular _size_**, and not **Hack _size_**, but the `theme.txt` file specifies fonts for various elements using the form **Hack _size_**. Note: the actual names of the fonts can be verified by viewing the Hack-*.pf2 files with a hex editor and looking at the [NAME field](http://grub.gibibit.com/New_font_format#id5).

Consequently, GRUB cannot find the fonts and substitutes other ones, which on my system are **huge**, so big, in fact, that most menu entries cannot fit on the screen, and making the theme very ugly.

This patch corrects the font names in the `theme.txt` file to match their names as given in the *.pf2 files, so GRUB is able to find the correct fonts, and the theme displays properly.